### PR TITLE
Refine setup plans with specification template

### DIFF
--- a/backend_setup_plan.md
+++ b/backend_setup_plan.md
@@ -1,0 +1,54 @@
+# Backend Setup Plan - Phase 1
+
+> Ingest the information from this file, implement the Low-Level Tasks, and generate the code that will satisfy the High and Mid-Level Objectives.
+
+## High-Level Objective
+
+- Establish the initial FastAPI backend scaffolding described in `react-refactoring-plan.md`.
+
+## Mid-Level Objective
+
+- Create the `backend/` directory tree with routers, services, and models subfolders.
+- Provide a `main.py` entry point exposing a `/health` endpoint.
+- Move `utils/llm_manager.py` into `backend/services/` and create placeholder service modules.
+- Add empty Pydantic model files under `backend/models/`.
+- Include a `dependencies.py` module and `requirements.txt` listing core packages.
+- Document how to start the backend in the root `README.md`.
+
+## Implementation Notes
+- Keep the existing `main.py` at repository root for reference.
+- All new modules should contain minimal placeholder content or TODO markers.
+- Follow PEP8 style for Python files.
+- Use FastAPI 0.110+, Pydantic 2+, and Uvicorn.
+
+## Context
+
+### Beginning context
+- `README.md`
+- `main.py`
+- `requirements.txt`
+- `utils/llm_manager.py`
+
+### Ending context
+- `backend/` with `main.py`, `routers/`, `services/`, `models/`, `dependencies.py`, and `requirements.txt`
+- Updated `README.md` describing backend startup
+
+## Low-Level Tasks
+> Ordered from start to finish
+
+1. Create backend directories and placeholder files
+```aider
+Use bash commands to make directories `backend`, `backend/routers`, `backend/services`, `backend/models`.
+Create empty files for routers (`practice.py`, `evaluation.py`, `assistance.py`, `languages.py`, `__init__.py`) each with a placeholder APIRouter.
+Create service files `llm_manager.py` (moved from utils), `language_support.py`, `code_execution.py` containing TODO comments.
+Create model files `__init__.py`, `schemas.py`, `prompts.py`, `languages.py` with TODOs.
+Create empty `dependencies.py` and `requirements.txt` listing FastAPI packages.
+```
+2. Implement `backend/main.py`
+```aider
+Create `backend/main.py` defining a FastAPI app that includes routers and exposes `/health` returning `{"status": "ok"}`.
+```
+3. Update documentation
+```aider
+Update `README.md` with a section explaining how to install backend dependencies and run the FastAPI app using `uvicorn backend.main:app`.
+```

--- a/frontend_setup_plan.md
+++ b/frontend_setup_plan.md
@@ -1,0 +1,55 @@
+# Frontend Setup Plan - Phase 1
+
+> Ingest the information from this file, implement the Low-Level Tasks, and generate the code that will satisfy the High and Mid-Level Objectives.
+
+## High-Level Objective
+
+- Create the initial React frontend scaffolding described in `react-refactoring-plan.md`.
+
+## Mid-Level Objective
+
+- Set up the `frontend/` directory with `public/` and `src/` subfolders.
+- Add placeholder component files matching the plan (e.g., `CodeEditor.jsx`, `QuestionGenerator.jsx`).
+- Provide minimal `App.jsx`, `index.jsx`, and `App.css` files.
+- Include a `package.json` with basic dependencies.
+- Document frontend setup instructions in `frontend/README.md` and reference it from the root `README.md`.
+
+## Implementation Notes
+- Components should export simple functional components returning a `<div>` with the component name.
+- Use modern React with ES modules.
+- Keep version numbers in `package.json` as placeholders (e.g., "0.1.0").
+- Development server may use `vite` or `react-scripts` depending on preference.
+
+## Context
+
+### Beginning context
+- `README.md`
+- `main.py`
+- `requirements.txt`
+- `utils/llm_manager.py`
+
+### Ending context
+- `frontend/` with `public/` and `src/` directories containing component stubs
+- `frontend/package.json` and `frontend/README.md`
+- Updated root `README.md` referencing frontend instructions
+
+## Low-Level Tasks
+> Ordered from start to finish
+
+1. Scaffold directories and component stubs
+```aider
+Create `frontend/public`, `frontend/src`, and nested component folders according to the refactoring plan.
+Add placeholder component files under `frontend/src/components/...` each exporting a React function returning a `<div>` with the component name.
+```
+2. Add application entry files
+```aider
+Create `frontend/src/App.jsx` with a basic "Hello World" component.
+Create `frontend/src/index.jsx` that renders `<App />`.
+Create `frontend/src/App.css` with minimal placeholder styles.
+```
+3. Configure package and documentation
+```aider
+Create `frontend/package.json` with placeholder name, version, and scripts for starting the dev server.
+Write `frontend/README.md` explaining how to install dependencies and run the dev server.
+Update the root `README.md` with a short section pointing to the frontend README.
+```


### PR DESCRIPTION
## Summary
- convert backend_setup_plan.md to specification template
- convert frontend_setup_plan.md to specification template

## Testing
- `pytest -q` *(fails: command not found)*