### PR TITLE
Fix import paths in ShadcnTestPage

### DIFF
--- a/frontend/src/pages/ShadcnTestPage.jsx
+++ b/frontend/src/pages/ShadcnTestPage.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
-import Button from '../components/ui/button';
-import Input from '../components/ui/input';
-import Card from '../components/ui/card';
+import Button from '../components/ui/Button';
+import Input from '../components/ui/Input';
+import Card from '../components/ui/Card';
 import { FiSettings, FiArrowRight, FiSearch, FiMail, FiLock, FiCheck, FiAlertCircle, FiCode, FiBox, FiCpu } from 'react-icons/fi';
 
 /**


### PR DESCRIPTION
## Summary
- use proper casing for component imports in `ShadcnTestPage.jsx`

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `pytest` *(fails: command not found)*