### PR TITLE
Add cn utility helper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,8 @@ downloads/
 eggs/
 .eggs/
 lib/
+!frontend/src/lib/
+!frontend/src/lib/**
 lib64/
 parts/
 sdist/

--- a/frontend/src/lib/utils.js
+++ b/frontend/src/lib/utils.js
@@ -1,0 +1,6 @@
+import { clsx } from 'clsx';
+import { twMerge } from 'tailwind-merge';
+
+export function cn(...inputs) {
+  return twMerge(clsx(inputs));
+}


### PR DESCRIPTION
## Summary
- add `frontend/src/lib/utils.js` to expose `cn`
- allow tracking `frontend/src/lib` in `.gitignore`
- verify existing components import the helper

## Testing
- `npm run build` *(fails: vite not found)*