### PR TITLE
Add readOnly props to read-only inputs

### DIFF
--- a/frontend/src/pages/ShadcnTestPage.jsx
+++ b/frontend/src/pages/ShadcnTestPage.jsx
@@ -237,6 +237,7 @@ function ShadcnTestPage() {
                   success
                   iconRight={<FiCheck />}
                   helperText="This looks good!"
+                  readOnly
                 />
                 <Input
                   name="error"
@@ -245,6 +246,7 @@ function ShadcnTestPage() {
                   error
                   iconRight={<FiAlertCircle />}
                   helperText="Please provide a valid value"
+                  readOnly
                 />
               </div>
             </div>
@@ -257,6 +259,7 @@ function ShadcnTestPage() {
                   label="Disabled Input"
                   value="Can't edit this"
                   disabled
+                  readOnly
                 />
                 <Input
                   name="readonly"


### PR DESCRIPTION
## Summary
- fix React warnings by setting `readOnly` on inputs that have a `value` but are not editable

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration)*
- `pytest -q` *(fails: command not found)*